### PR TITLE
Disable serialport features for easier cross compiling

### DIFF
--- a/actuator/robstride/Cargo.toml
+++ b/actuator/robstride/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.3", features = ["derive"] }
 serde = { version = "^1.0", features = ["derive"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
-serialport = "^4.2.0"
+serialport = { version = "^4.2.0", default-features = false }
 
 [[bin]]
 


### PR DESCRIPTION
Disabling default-features for serialport should remove dependency on libudev which is a pain to cross compile in CI-able manner (and is not used in this project)